### PR TITLE
feat(gs-merge): wait for pending CI instead of stopping

### DIFF
--- a/skills/gs-merge/SKILL.md
+++ b/skills/gs-merge/SKILL.md
@@ -73,11 +73,30 @@ For each PR to merge, execute these steps in strict order. Complete the full cyc
 gh pr checks <number>
 ```
 
-All checks must have status `pass` or `skipping`. If any check is `fail` or `pending`, stop immediately:
+Evaluate the results:
 
-> PR #N has failing/pending CI checks: [list check names and statuses]. Aborting.
+- **All checks `pass` or `skipping`:** Continue to step 6b.
+- **Any check `fail`:** Stop immediately:
+  > PR #N has failing CI checks: [list check names and statuses]. Aborting.
+- **Any check `pending` or `in_progress` (none failing):** Ask the user:
+  > PR #N has pending CI checks: [list check names and statuses].
+  > Wait for CI to complete? (yes / no)
 
-Do not proceed to the next step.
+  **If no:** Stop immediately and report.
+
+  **If yes:** Poll `gh pr checks <number>` every 30 seconds until all checks resolve:
+
+  ```bash
+  # Repeat until no checks are pending/in_progress:
+  gh pr checks <number>
+  # Wait 30 seconds between polls
+  ```
+
+  - After each poll, if any check changed state, show a brief status update (e.g., "lint: pass, tests: still running...").
+  - Once all checks resolve:
+    - All `pass` or `skipping` → continue to step 6b.
+    - Any `fail` → stop and report, same as above.
+  - If the user interrupts during polling → stop and report the current check state.
 
 #### 6b. Check review threads
 
@@ -205,6 +224,7 @@ Merged: 2, Stopped at: PR #177, Remaining: 1
 Possible statuses per row:
 - `Merged ✓` — PR merged, branch deleted, downstream rebased
 - `CI failing ✗ (stopped)` — CI check failed; halted here
+- `CI pending ✗ (stopped)` — user chose not to wait for pending CI
 - `Unresolved reviews ✗ (stopped)` — user chose to abort on unresolved threads
 - `Not attempted` — would have been merged next but a prior stop prevented it
 
@@ -215,6 +235,7 @@ Possible statuses per row:
 - **Always** use `--force-with-lease` for all pushes, never bare `--force`
 - **Always** present the stack and get user confirmation before any merge
 - **Stop** on CI failure — do not skip and continue
+- **Ask** on pending CI — offer to wait with polling, never auto-wait
 - **Ask** on unresolved review threads — do not auto-proceed
 - **Never** auto-resolve genuine rebase conflicts — pause and wait for the user
 - Clean up `git-stack.*` config entries for every merged branch

--- a/skills/gs-merge/SKILL.md
+++ b/skills/gs-merge/SKILL.md
@@ -70,33 +70,33 @@ For each PR to merge, execute these steps in strict order. Complete the full cyc
 #### 6a. Check CI
 
 ```bash
-gh pr checks <number>
+gh pr checks <number> --json name,state
 ```
 
-Evaluate the results:
+Evaluate the results. The `state` field returns values like `SUCCESS`, `FAILURE`, `PENDING`, `SKIPPED`, etc. (casing may vary by `gh` version — check case-insensitively). Check for failures first — a failing check takes priority over any pending checks:
 
-- **All checks `pass` or `skipping`:** Continue to step 6b.
-- **Any check `fail`:** Stop immediately:
-  > PR #N has failing CI checks: [list check names and statuses]. Aborting.
-- **Any check `pending` or `in_progress` (none failing):** Ask the user:
-  > PR #N has pending CI checks: [list check names and statuses].
+- **All checks `SUCCESS` or `SKIPPED`:** Continue to step 6b.
+- **Any check `FAILURE` or `ERROR` (regardless of other checks' states):** Stop immediately:
+  > PR #N has failing CI checks: [list check names and states]. Aborting.
+- **Any check `PENDING` or `IN_PROGRESS` (and none failing):** Ask the user:
+  > PR #N has pending CI checks: [list check names and states].
   > Wait for CI to complete? (yes / no)
 
   **If no:** Stop immediately and report.
 
-  **If yes:** Poll `gh pr checks <number>` every 30 seconds until all checks resolve:
+  **If yes:** Poll every 30 seconds until all checks resolve:
 
   ```bash
-  # Repeat until no checks are pending/in_progress:
-  gh pr checks <number>
-  # Wait 30 seconds between polls
+  sleep 30
+  gh pr checks <number> --json name,state
   ```
 
-  - After each poll, if any check changed state, show a brief status update (e.g., "lint: pass, tests: still running...").
+  - After each poll, if any check changed state since the last poll, show a brief update (e.g., "lint: SUCCESS, tests: still PENDING...").
   - Once all checks resolve:
-    - All `pass` or `skipping` → continue to step 6b.
-    - Any `fail` → stop and report, same as above.
-  - If the user interrupts during polling → stop and report the current check state.
+    - All `SUCCESS` or `SKIPPED` → continue to step 6b.
+    - Any `FAILURE` or `ERROR` → stop and report, same as above.
+  - If any checks are still `PENDING` or `IN_PROGRESS` after 10 minutes (20 polls), report the current state and ask the user whether to keep waiting or stop.
+  - If the user sends a message during polling, treat it as an interrupt — stop polling, report the current check state, and respond to the user.
 
 #### 6b. Check review threads
 
@@ -251,4 +251,6 @@ Possible statuses per row:
 - **Push rejected (lease mismatch):** Report the error, tell the user to run `/gs-sync` first, and stop. Do not retry automatically.
 - **`gh pr edit --base` fails:** Report the error and stop. Do not delete the branch until retargeting succeeds.
 - **Last PR in stack (no next PR):** Skip the retarget step (step 6d). Delete the branch normally.
+- **CI wait timeout:** After 10 minutes of polling with checks still pending, ask the user whether to keep waiting or stop. If the user stops, report `CI pending ✗ (stopped)`.
+- **No CI checks configured:** If `gh pr checks` returns an empty list, treat as all passing and continue to step 6b.
 - **No `git-stack.*` config and no open PRs:** Stop with: "No stack found. Use `/gs-create` to start one."


### PR DESCRIPTION
## Summary

- When `/gs-merge` encounters pending CI checks, it now asks the user whether to wait instead of stopping immediately
- If the user chooses to wait, polls `gh pr checks` every 30 seconds with status updates until all checks resolve
- Continues the merge flow on pass, stops on failure — same as before

Closes #1