### PR TITLE
feat: add /gs-nav skill for stack navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-claude-ghstack is a Claude Code plugin for stacked PR management. It provides eight slash-command skills (`/gs-*`) that create, reorder, publish, sync, and merge stacked branches without leaving the editor. There is no build step, no tests, and no runtime code — the repo is entirely markdown-based skill definitions.
+claude-ghstack is a Claude Code plugin for stacked PR management. It provides nine slash-command skills (`/gs-*`) that create, reorder, publish, sync, and merge stacked branches without leaving the editor. There is no build step, no tests, and no runtime code — the repo is entirely markdown-based skill definitions.
 
 ## Development
 
@@ -36,7 +36,7 @@ All stack state lives in `.git/config` under `git-stack.<branch>.parent` keys. N
 
 ### Skill Categories
 
-- **Local-only** (no `gh` needed): `gs-create`, `gs-insert`, `gs-move` — use simple stack discovery (git config only), require clean tree (no merge conflicts)
+- **Local-only** (no `gh` needed): `gs-create`, `gs-insert`, `gs-move`, `gs-nav` — use simple stack discovery (git config only). `gs-create`/`gs-insert`/`gs-move` require clean tree; `gs-nav` lets git handle checkout conflicts naturally.
 - **Network** (`gh` required): `gs-submit`, `gs-sync`, `gs-merge` — use full stack discovery with PR chain fallback, delegate to prerequisites.md
 - **Read-only**: `gs-log` (display only, no mutations), `gs-help` (static reference card)
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ Run `/gs-help` to verify the plugin is active.
 
 ## What claude-ghstack does
 
-claude-ghstack provides eight slash commands that handle the entire stacked PR lifecycle. Local commands work offline; network commands require the [GitHub CLI](https://cli.github.com/).
+claude-ghstack provides nine slash commands that handle the entire stacked PR lifecycle. Local commands work offline; network commands require the [GitHub CLI](https://cli.github.com/).
 
 | Command      | Description                                                                 |
 | ------------ | --------------------------------------------------------------------------- |
 | `/gs-create` | Create a new branch stacked on the current one, stage changes, and commit   |
 | `/gs-insert` | Insert a new branch at a chosen position in an existing stack               |
 | `/gs-move`   | Reorder a branch (move up/down/to position) or detach it from the stack     |
+| `/gs-nav`    | Switch to another branch in the stack (next, prev, by number, or pick)      |
 | `/gs-submit` | Push all branches and create/update PRs on GitHub with proper base branches |
 | `/gs-sync`   | Rebase the entire stack after upstream changes, optionally push             |
 | `/gs-merge`  | Merge approved PRs into `main` with automatic retarget, cleanup, and rebase |

--- a/skills/gs-help/SKILL.md
+++ b/skills/gs-help/SKILL.md
@@ -9,6 +9,7 @@ Stacked PR Skills (claude-ghstack plugin)
     /gs-create   — Create a new branch stacked on current
     /gs-insert   — Insert a branch at a chosen position in the stack
     /gs-move     — Reorder or detach a branch in the stack
+    /gs-nav      — Switch to another branch in the stack
 
   Network operations:
     /gs-submit   — Push all branches + create/update PRs

--- a/skills/gs-nav/SKILL.md
+++ b/skills/gs-nav/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: gs-nav
+description: Use when the user wants to switch to another branch in the stack, navigate the stack, jump to a specific stack position, or runs /gs-nav.
+---
+
+You are implementing `/gs-nav`. This switches to another branch in the current stack. No mutations to branches, metadata, or PRs.
+
+The user may invoke this as `/gs-nav` (interactive), `/gs-nav next`, `/gs-nav 2`, etc.
+
+## Steps
+
+### 1. Discover the stack
+
+**Follow the [stack discovery](../../docs/stack-discovery.md) pattern** (git config only, no fallback). Build the ordered branch list from root to tip. If no stack is found, stop and report: "No stack found. Use `/gs-create` to start one."
+
+Get the current branch:
+```
+git rev-parse --abbrev-ref HEAD
+```
+
+Determine the current branch's position in the stack (1-indexed, where 1 is closest to `main`). If the current branch is `main` or not in the stack, note this — the user can still navigate.
+
+### 2. Parse the argument
+
+The user may pass an argument after `/gs-nav`. Parse it as follows:
+
+| Argument | Action |
+|---|---|
+| *(none)* | Interactive mode — show the stack and ask the user to pick (see step 3) |
+| `next` or `n` | Move one branch farther from `main` (the child branch) |
+| `prev` or `p` | Move one branch closer to `main` (the parent branch) |
+| `first` or `f` | Jump to the branch closest to `main` (first in the stack) |
+| `last` or `l` | Jump to the branch farthest from `main` (tip of the stack) |
+| `main` | Check out `main` (exit the stack) |
+| A number (e.g. `3`) | Jump to the Nth branch in the stack (1-indexed, 1 = closest to `main`) |
+
+If the argument doesn't match any of the above, report: "Unknown argument. Use `next`, `prev`, `first`, `last`, `main`, or a branch number."
+
+### 3. Interactive mode (no argument)
+
+Show the stack with numbered branches and the current position:
+
+```
+Stack:
+  main
+    ↓
+  [1] feat/auth
+    ↓
+  [2] feat/api         ← (you are here)
+    ↓
+  [3] feat/ui
+
+Jump to: [number] / [n]ext / [p]rev / [f]irst / [l]ast / [main]
+```
+
+Wait for the user's response, then parse it using the same rules as step 2.
+
+### 4. Validate the target
+
+Before checking out, validate:
+
+- **`next` from `main`:** Jump to the first stacked branch (closest to `main`). This is not an error — proceed to step 5.
+- **`next` from the tip:** Report "Already at the last branch in the stack (farthest from main). Nowhere to go." and stop.
+- **`prev` from the first branch:** Report "Already the first branch in the stack (closest to main). Use `/gs-nav main` to check out main." and stop.
+- **`prev` from `main`:** Report "Already on main." and stop.
+- **Number out of range:** Report "Branch number N is out of range. The stack has N branches." and stop.
+- **Already on the target branch:** Report "Already on [branch name]." and stop.
+
+### 5. Check out the target branch
+
+```
+git checkout <target-branch>
+```
+
+If the checkout fails (e.g., uncommitted changes conflict with the target branch), report the git error to the user. Do not add a blanket dirty-tree pre-check — let git handle it naturally.
+
+### 6. Confirm
+
+Show a one-line confirmation with position context:
+
+```
+Switched to feat/ui (3 of 3, last in stack)
+```
+
+Position labels:
+- Branch 1: `(1 of N, first in stack)`
+- Branch N (last): `(N of N, last in stack)`
+- Any other: `(M of N)`
+- `main`: `(main, outside stack)`
+
+The skill is done. No further action, no follow-up questions.
+
+## Rules
+
+- Read-only — never modify branches, metadata, or PRs
+- Never add a blanket dirty-tree pre-check — let `git checkout` fail naturally if there are conflicts
+- `gh` is not required — this is entirely local
+- In interactive mode, wait for the user to choose before checking out
+- Use "closer to `main`" / "farther from `main`" for direction — never "top" / "bottom"
+
+## Edge Cases
+
+- **Current branch is `main`:** The user is outside the stack. `next` jumps to the first stacked branch. `prev` reports "Already on main." Interactive mode still shows the full stack.
+- **Current branch is not part of the discovered stack:** A stack exists (git config has `git-stack.*` keys) but the current branch isn't in it. Report "Current branch is not part of this stack." and show the stack so the user can pick a branch to navigate to.
+- **Stack has only one branch:** `next` and `prev` both report they're at the edge. `first` and `last` both go to the same branch. Number `1` works.
+- **Checkout fails due to uncommitted changes:** Report the git error and suggest: "Commit or stash your changes first, or use `/gs-create` to start a new branch with your current changes."
+- **Argument is a branch name instead of a number:** Not supported — report the unknown argument message. The user should use the number or interactive mode.


### PR DESCRIPTION
## Summary

- New `/gs-nav` skill for switching between branches in a stack
- Interactive picker (no args) or shorthand arguments: `next`/`prev`/`first`/`last`/number/`main`
- Local-only, no `gh` required, no dirty-tree pre-check (lets git handle conflicts)
- Updates gs-help reference card, README command table, and CLAUDE.md skill categories

Closes #3