### PR TITLE
fix: replace hardcoded main with dynamic root branch detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,10 @@ Skills reference these via relative links like `../../docs/stack-discovery.md`. 
 
 ### Stack Metadata
 
-All stack state lives in `.git/config` under `git-stack.<branch>.parent` keys. No files are committed or tracked. Skills read/write this config directly via `git config`.
+All stack state lives in `.git/config` under `git-stack.*` keys. No files are committed or tracked. Skills read/write this config directly via `git config`.
+
+- `git-stack.root` — the base branch name (e.g., `main`, `master`). Detected via `gh` on first stack creation, read by all skills. Skills must never hardcode `main` — always use the value from `git config git-stack.root`.
+- `git-stack.<branch>.parent` — the parent branch for each stacked branch.
 
 ### Skill Categories
 
@@ -57,14 +60,14 @@ When adding or editing skills:
 - Compare local vs remote with `git rev-parse` on both refs (not `git diff`)
 - All local skills start with a dirty-tree pre-check (`git status --porcelain`)
 - All mutating skills end with a verification step (read `CLAUDE.md` for project commands)
-- Use "closer to `main`" / "farther from `main`" for direction — never "top" / "bottom"
+- Use "closer to `<root-branch>`" / "farther from `<root-branch>`" for direction — never "top" / "bottom"
 
 ## Key Conventions Across Skills
 
 - Always use `--force-with-lease`, never bare `--force`
 - Never add `Co-Authored-By` lines or "Generated with Claude Code" lines
 - Always confirm branch names, commit messages, and PR descriptions with the user before acting
-- Rebase order is always bottom-to-top (closest to `main` first)
-- Bottom branch rebases onto `origin/main`; subsequent branches rebase onto their local parent
-- PR base is always the branch's `.parent` in stack metadata, not hardcoded to `main`
+- Rebase order is always bottom-to-top (closest to `<root-branch>` first)
+- Bottom branch rebases onto `origin/<root-branch>`; subsequent branches rebase onto their local parent
+- PR base is always the branch's `.parent` in stack metadata — never hardcoded
 - Never push branches that haven't been published yet — those must go through `/gs-submit` for PR approval

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ claude-ghstack provides nine slash commands that handle the entire stacked PR li
 | `/gs-nav`    | Switch to another branch in the stack (next, prev, by number, or pick)      |
 | `/gs-submit` | Push all branches and create/update PRs on GitHub with proper base branches |
 | `/gs-sync`   | Rebase the entire stack after upstream changes, optionally push             |
-| `/gs-merge`  | Merge approved PRs into `main` with automatic retarget, cleanup, and rebase |
+| `/gs-merge`  | Merge approved PRs into the base branch with automatic retarget and cleanup |
 | `/gs-log`    | Display the stack graph with PR status, CI checks, and review state         |
 | `/gs-help`   | Show the quick reference card                                               |
 
@@ -166,6 +166,7 @@ claude-ghstack provides nine slash commands that handle the entire stacked PR li
 Stack metadata is stored in `.git/config` under `git-stack.*` keys — no extra files to commit or track. Each branch records its parent, forming a linked list:
 
 ```
+git-stack.root             = main
 git-stack.feat/auth.parent = main
 git-stack.feat/api.parent  = feat/auth
 git-stack.feat/ui.parent   = feat/api
@@ -175,7 +176,9 @@ main ──▶ feat/auth ──▶ feat/api ──▶ feat/ui
            main          feat/auth    feat/api
 ```
 
-Each command reads the stack state by following these parent pointers, performs its operation, and updates the config. The chain is walked bottom-up (closest to `main` first) for rebasing and submitting, ensuring each branch is always based on the correct parent.
+The `git-stack.root` key stores the base branch name (detected automatically on first stack creation). The plugin works with any default branch — not just `main`.
+
+Each command reads the stack state by following these parent pointers, performs its operation, and updates the config. The chain is walked bottom-up (closest to the root first) for rebasing and submitting, ensuring each branch is always based on the correct parent.
 
 ### Key design decisions
 

--- a/docs/stack-discovery.md
+++ b/docs/stack-discovery.md
@@ -1,5 +1,25 @@
 # Stack Discovery Pattern
 
+## Determine the root branch
+
+Before building the branch list, read the stored root branch:
+
+```bash
+git config git-stack.root
+```
+
+If the command returns a value, store it as `<root-branch>`.
+
+If no value is set (legacy stack or first discovery), walk the parent pointers to find the branch with no `git-stack.*.parent` entry — that is the root. Then persist it:
+
+```bash
+git config git-stack.root <detected-root>
+```
+
+Return `<root-branch>` alongside the ordered branch list for all callers. All skills must use `<root-branch>` instead of hardcoding `main`.
+
+---
+
 ## Full version (with PR chain fallback)
 
 Use this version in skills that have `gh` available (gs-sync, gs-merge, gs-submit, gs-log).
@@ -10,7 +30,7 @@ Use this version in skills that have `gh` available (gs-sync, gs-merge, gs-submi
 git config --get-regexp "git-stack\."
 ```
 
-This returns lines like `git-stack.<branch>.parent <parent-branch>`. Parse the output to build parent→child relationships and reconstruct the ordered branch list from root (e.g. `main`) to tip by following `.parent` pointers.
+This returns lines like `git-stack.<branch>.parent <parent-branch>`. Parse the output to build parent→child relationships and reconstruct the ordered branch list from `<root-branch>` to tip by following `.parent` pointers.
 
 ### 2. Fallback — walk PR chain
 
@@ -20,12 +40,14 @@ If no `git-stack.*` keys exist, auto-detect from GitHub:
 # Get PR info for current branch
 gh pr list --head <current-branch> --state open --json number,baseRefName,headRefName --jq '.[0]'
 
-# Walk down to root (follow base refs until reaching main)
+# Walk down to root (follow base refs until no further open PR exists)
 gh pr list --head <base-branch> --state open --json number,baseRefName,headRefName --jq '.[0]'
 
 # Walk up from root (find PRs stacked on top)
 gh pr list --base <branch> --state open --json number,headRefName,baseRefName --jq '.[0]'
 ```
+
+The walk terminates when a `baseRefName` has no open PR targeting it — that branch is the root. Store it as `<root-branch>` and persist it: `git config git-stack.root <root-branch>`.
 
 If the fallback finds a stack, populate git config for future use:
 

--- a/skills/gs-create/SKILL.md
+++ b/skills/gs-create/SKILL.md
@@ -21,7 +21,7 @@ Staged and unstaged changes are fine — they will be handled in step 6.
 
 ### 2. Discover the current stack position
 
-**Follow the [stack discovery](../../docs/stack-discovery.md) pattern** (git config only, no fallback). Display the relevant portion of the stack so the user can see where they are. If the current branch is `main`, note that this will start a new stack.
+**Follow the [stack discovery](../../docs/stack-discovery.md) pattern** (git config only, no fallback). Display the relevant portion of the stack so the user can see where they are.
 
 Get the current branch name:
 ```
@@ -29,6 +29,30 @@ git rev-parse --abbrev-ref HEAD
 ```
 
 Store it as `<current-branch>`.
+
+**If no stack exists yet** (no `git-stack.*` keys), this will start a new stack. Detect the repository's default branch:
+
+```bash
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+```
+
+Store the result as `<root-branch>`. If `gh` is unavailable, fall back to:
+
+```bash
+git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'
+```
+
+If both fail, default to `main` and confirm with the user:
+
+> Assuming `main` as the base branch. Is this correct? (yes / type the correct branch name)
+
+Once determined, persist the root:
+
+```bash
+git config git-stack.root <root-branch>
+```
+
+If the current branch is `<root-branch>`, note that this will start a new stack.
 
 ### 3. Determine the new branch name
 
@@ -107,7 +131,7 @@ Show a summary:
 
 ## Edge Cases
 
-- **Current branch is `main`:** This starts a new stack. Parent will be `main`. Proceed normally.
+- **Current branch is `<root-branch>`:** This starts a new stack. Parent will be `<root-branch>`. Proceed normally.
 - **Current branch already has a child in the stack:** The new branch is stacked on top of the current branch (at the current HEAD), not inserted between the current branch and its existing child. The existing child's parent is not modified.
 - **No changes to commit:** Ask the user whether to create an empty branch (branch + metadata only) or cancel. See step 6.
 - **Dirty index with conflicts:** If `git status` shows merge conflicts, stop and tell the user to resolve conflicts before creating a stack branch.

--- a/skills/gs-help/SKILL.md
+++ b/skills/gs-help/SKILL.md
@@ -14,7 +14,7 @@ Stacked PR Skills (claude-ghstack plugin)
   Network operations:
     /gs-submit   — Push all branches + create/update PRs
     /gs-sync     — Rebase the stack + optionally push
-    /gs-merge    — Merge PRs into main with cleanup
+    /gs-merge    — Merge PRs into base branch with cleanup
 
   Info:
     /gs-log      — Show the stack graph with PR status
@@ -23,7 +23,7 @@ Stacked PR Skills (claude-ghstack plugin)
   Typical workflow:
     1. /gs-create to build your stack locally
     2. /gs-submit to publish PRs
-    3. /gs-sync after changes or main updates
+    3. /gs-sync after changes or base branch updates
     4. /gs-merge when PRs are approved
 
   Metadata is stored in .git/config (git-stack.* keys).

--- a/skills/gs-insert/SKILL.md
+++ b/skills/gs-insert/SKILL.md
@@ -32,7 +32,7 @@ Display the full stack graph with numbered insertion points between each adjacen
 
 ```
 Stack:
-  main
+  <root-branch>
     ↓  ← [1] insert here
   stack/03-use-date-locale
     ↓  ← [2] insert here
@@ -41,7 +41,7 @@ Stack:
   stack/05-data-table-meta
 ```
 
-Insertion position `[1]` means between `main` and the first stacked branch. The last position means between the last branch and the tip (appending to the end of the stack).
+Insertion position `[1]` means between `<root-branch>` and the first stacked branch. The last position means between the last branch and the tip (appending to the end of the stack).
 
 ### 4. Ask for the insertion position
 
@@ -130,7 +130,7 @@ git checkout <branch>
 # run verification commands
 ```
 
-Work through branches from the one closest to `main` to the tip. After verification, return to the new branch:
+Work through branches from the one closest to `<root-branch>` to the tip. After verification, return to the new branch:
 
 ```
 git checkout <new-branch>
@@ -162,7 +162,7 @@ Show a summary:
 
 - **No stack exists:** Report error and suggest `/gs-create`.
 - **Inserting at the tip (no branch below):** No downstream rebase needed. Only set `git-stack.<new-branch>.parent <branch-above>`.
-- **Inserting at position [1] (between root and first stacked branch):** `<branch-above>` is `main` (or the stack root). `<branch-below>` is the first stacked branch — update its parent to point to the new branch, then rebase all downstream.
+- **Inserting at position [1] (between root and first stacked branch):** `<branch-above>` is `<root-branch>`. `<branch-below>` is the first stacked branch — update its parent to point to the new branch, then rebase all downstream.
 - **Rebase conflicts:** Stop, show the conflicting branch, instruct the user to resolve manually, and explain how to continue (`git rebase --continue`).
 - **Dirty index with conflicts:** If `git status` shows merge conflicts before starting, stop and tell the user to resolve conflicts first.
 - **Current branch is in the downstream:** After the rebase, the user's original current branch will have been rebased. Ensure `git checkout <new-branch>` lands correctly.

--- a/skills/gs-log/SKILL.md
+++ b/skills/gs-log/SKILL.md
@@ -23,7 +23,7 @@ git rev-parse --abbrev-ref HEAD
 
 ### 3. Gather Info Per Branch
 
-For each branch in the stack (from the branch farthest from `main` to the one closest):
+For each branch in the stack (from the branch farthest from `<root-branch>` to the one closest):
 
 **Commit count vs parent:**
 ```bash
@@ -83,12 +83,12 @@ Format rules:
 - Other branches: prefix with two spaces for alignment
 - PR number rendered as a clickable markdown link: `[PR #N](url)`
 - Commit count: `N commit` (singular) or `N commits` (plural)
-- The root anchor (e.g. `main`) has no PR info or commit count
+- The root anchor (`<root-branch>`) has no PR info or commit count
 
 **Example output:**
 
 ```
-  main
+  <root-branch>
     ↓
   stack/03-use-date-locale ([PR #175](https://github.com/owner/repo/pull/175) ✓ ready) 1 commit
     ↓

--- a/skills/gs-merge/SKILL.md
+++ b/skills/gs-merge/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: gs-merge
-description: Use when the user wants to merge stacked PRs into main, land approved PRs from the stack, or runs /gs-merge.
+description: Use when the user wants to merge stacked PRs into the base branch, land approved PRs from the stack, or runs /gs-merge.
 ---
 
-You are implementing `/gs-merge`. This merges one or all PRs from a stacked PR chain into main with full cleanup.
+You are implementing `/gs-merge`. This merges one or all PRs from a stacked PR chain into the base branch with full cleanup.
 
 ## Steps
 
@@ -21,7 +21,7 @@ Show the discovered stack and ask for confirmation:
 
 ```
 Stack detected (N PRs):
-  1. stack/01-feature-a  (PR #42)  → base: main
+  1. stack/01-feature-a  (PR #42)  → base: <root-branch>
   2. stack/02-feature-b  (PR #43)  → base: stack/01-feature-a
   3. stack/03-feature-c  (PR #44)  → base: stack/02-feature-b
 
@@ -55,7 +55,7 @@ Ask the user to pick a strategy, recommending squash if available:
 ```
 Merge strategy?
   1. Squash (recommended) — combines all commits into one
-  2. Rebase — replays commits individually onto main
+  2. Rebase — replays commits individually onto the base branch
   3. Merge commit — creates a merge commit
 ```
 
@@ -134,22 +134,22 @@ gh pr merge <number> --squash    # or --rebase or --merge based on chosen strate
 
 This must happen before the merged branch is deleted, so GitHub can correctly update the diff.
 
-**If scope is "all":** Only the immediate next PR needs retargeting (its base becomes `main`), since the merge cycle will process it next:
+**If scope is "all":** Only the immediate next PR needs retargeting (its base becomes `<root-branch>`), since the merge cycle will process it next:
 
 ```bash
-gh pr edit <next-pr-number> --base main
+gh pr edit <next-pr-number> --base <root-branch>
 ```
 
 Update its stack metadata to reflect the new parent:
 ```bash
-git config git-stack.<next-branch>.parent main
+git config git-stack.<next-branch>.parent <root-branch>
 ```
 
-**If scope is "next" (merge only one PR):** The immediate next PR must be retargeted to `main`, AND its stack metadata must be updated. All further downstream branches keep their existing parent pointers (they still chain off each other correctly):
+**If scope is "next" (merge only one PR):** The immediate next PR must be retargeted to `<root-branch>`, AND its stack metadata must be updated. All further downstream branches keep their existing parent pointers (they still chain off each other correctly):
 
 ```bash
-gh pr edit <next-pr-number> --base main
-git config git-stack.<next-branch>.parent main
+gh pr edit <next-pr-number> --base <root-branch>
+git config git-stack.<next-branch>.parent <root-branch>
 ```
 
 After the full merge cycle completes for the single PR (including rebase in step 6g), report to the user:
@@ -173,13 +173,13 @@ The `git branch -D` is local cleanup — if the branch does not exist locally, i
 git fetch origin
 ```
 
-This updates `origin/main` to the post-merge state before rebasing.
+This updates `origin/<root-branch>` to the post-merge state before rebasing.
 
 #### 6g. Rebase remaining stack
 
-For each remaining branch in the stack, in order from the branch closest to `main` outward to the tip:
+For each remaining branch in the stack, in order from the branch closest to `<root-branch>` outward to the tip:
 
-- The **first remaining branch** rebases onto `origin/main`
+- The **first remaining branch** rebases onto `origin/<root-branch>`
 - Each **subsequent branch** rebases onto the locally-rebased branch below it (not its remote)
 
 For each branch:
@@ -231,7 +231,7 @@ Possible statuses per row:
 ## Rules
 
 - **Never** use `--delete-branch` during merge — branch must survive until the next PR is retargeted
-- **Always** retarget the next PR's base to `main` before deleting the merged branch
+- **Always** retarget the next PR's base to `<root-branch>` before deleting the merged branch
 - **Always** use `--force-with-lease` for all pushes, never bare `--force`
 - **Always** present the stack and get user confirmation before any merge
 - **Stop** on CI failure — do not skip and continue

--- a/skills/gs-move/SKILL.md
+++ b/skills/gs-move/SKILL.md
@@ -5,6 +5,8 @@ description: Use when the user wants to change a branch's position in the stack,
 
 You are implementing `/gs-move`. This reorders a branch within the stack, or detaches it entirely. No pushing, no PRs.
 
+**Note:** Examples below use `main` as the root branch. In practice, use `<root-branch>` (read from `git config git-stack.root`) wherever `main` appears in commands.
+
 ## Steps
 
 ### 1. Check working tree
@@ -30,7 +32,7 @@ Display the full stack with the current branch marked. Example:
 
 ```
 Stack:
-  main
+  <root-branch>
   └─ stack/01-feature-a
   └─ stack/02-feature-b  ← (you are here)
   └─ stack/03-feature-c
@@ -41,10 +43,10 @@ Stack:
 Present the following options:
 
 > What would you like to do?
-> 1. Move up — swap with the parent branch (move closer to main)
-> 2. Move down — swap with the child branch (move further from main)
+> 1. Move up — swap with the parent branch (move closer to `<root-branch>`)
+> 2. Move down — swap with the child branch (move further from `<root-branch>`)
 > 3. Move to position — pick a specific position in the stack
-> 4. Detach — remove from stack and make it a standalone branch off main
+> 4. Detach — remove from stack and make it a standalone branch off `<root-branch>`
 
 Wait for the user to choose. Then proceed to the matching section below.
 
@@ -54,8 +56,8 @@ Wait for the user to choose. Then proceed to the matching section below.
 
 Swap the current branch with the one immediately above it.
 
-**Precondition:** the current branch must not already be the closest to `main` (i.e. its parent cannot be the stack root such as `main`). If it is, report:
-> Already the first branch in the stack (closest to main). Nothing to move.
+**Precondition:** the current branch must not already be the closest to `<root-branch>` (i.e. its parent cannot be `<root-branch>`). If it is, report:
+> Already the first branch in the stack (closest to `<root-branch>`). Nothing to move.
 
 **Example:**
 
@@ -65,13 +67,13 @@ After "move up": `main → B → A → C`
 
 Metadata updates:
 ```
-git config git-stack.B.parent main
+git config git-stack.B.parent <root-branch>
 git config git-stack.A.parent B
 git config git-stack.C.parent A
 ```
 
 Rebase order (use `--onto` to transplant each branch from its old parent to its new parent):
-1. `git rebase --onto B main A` (transplant A from main to B)
+1. `git rebase --onto B <root-branch> A` (transplant A from `<root-branch>` to B)
 2. `git rebase --onto A B C` (transplant C from B to A)
 
 Return to `B` when done.
@@ -94,8 +96,8 @@ Let `current` = current branch, `above` = its parent, `above-parent` = parent of
 
 Swap the current branch with the one immediately below it.
 
-**Precondition:** the current branch must not already be at the tip of the stack (farthest from `main`, with no child branch). If it is, report:
-> Already the last branch in the stack (farthest from main). Nothing to move.
+**Precondition:** the current branch must not already be at the tip of the stack (farthest from `<root-branch>`, with no child branch). If it is, report:
+> Already the last branch in the stack (farthest from `<root-branch>`). Nothing to move.
 
 **Example:**
 
@@ -136,7 +138,7 @@ Show the stack with numbered insertion positions (like `/gs-insert`). Example:
 
 ```
 Stack:
-  main
+  <root-branch>
     ↓  ← [1] move here
   stack/01-feature-a
     ↓  ← [2] move here
@@ -160,13 +162,13 @@ Once the target position is chosen, update metadata and rebase as needed:
 
 ## Action: Detach
 
-Remove the current branch from the stack entirely and make it a standalone branch off main.
+Remove the current branch from the stack entirely and make it a standalone branch off `<root-branch>`.
 
 **Example:**
 
 Stack before: `main → A → B → C`. User detaches `B`.
 
-Result: stack is `main → A → C`, `B` is standalone off main.
+Result: stack is `main → A → C`, `B` is standalone off `<root-branch>`.
 
 Metadata updates:
 ```
@@ -175,7 +177,7 @@ git config --unset git-stack.B.parent
 ```
 
 Rebase order (use `--onto` to transplant each branch from its old parent to its new parent):
-1. `git rebase --onto main A B` (transplant B from A to main)
+1. `git rebase --onto <root-branch> A B` (transplant B from A to `<root-branch>`)
 2. `git rebase --onto A B C` (transplant C from B to A, closing the gap)
 
 Return to `B` when done.
@@ -189,7 +191,7 @@ Let `current` = current branch, `parent` = parent of `current`, `below` = child 
    ```
    git config --unset git-stack.current.parent
    ```
-3. `git rebase --onto main parent current` (transplant `current` from `parent` to `main`).
+3. `git rebase --onto <root-branch> parent current` (transplant `current` from `parent` to `<root-branch>`).
 4. If `below` exists: `git rebase --onto parent current below` (transplant `below` from `current` to `parent`), then continue rebasing any further downstream branches with `git rebase --onto <new-parent> <old-parent> <branch>`, in order.
 5. Return to `current`.
 
@@ -217,7 +219,7 @@ Report any failures. Do not declare the move complete until the user has acknowl
 ## Edge Cases
 
 - **Stack has only one branch:** Moving up or down is not possible. Detach is allowed. Report appropriately.
-- **Current branch is closest to main (parent = main):** "Move up" is a no-op. Report and stop.
-- **Current branch is farthest from main (no child):** "Move down" is a no-op. Report and stop.
-- **Detaching the only branch in the stack:** Unset metadata and rebase onto main. The stack becomes empty.
+- **Current branch is closest to `<root-branch>` (parent = `<root-branch>`):** "Move up" is a no-op. Report and stop.
+- **Current branch is farthest from `<root-branch>` (no child):** "Move down" is a no-op. Report and stop.
+- **Detaching the only branch in the stack:** Unset metadata and rebase onto `<root-branch>`. The stack becomes empty.
 - **Dirty working tree:** If `git status` shows uncommitted changes or unresolved conflicts before starting, stop and tell the user to clean up first.

--- a/skills/gs-nav/SKILL.md
+++ b/skills/gs-nav/SKILL.md
@@ -18,7 +18,7 @@ Get the current branch:
 git rev-parse --abbrev-ref HEAD
 ```
 
-Determine the current branch's position in the stack (1-indexed, where 1 is closest to `main`). If the current branch is `main` or not in the stack, note this — the user can still navigate.
+Determine the current branch's position in the stack (1-indexed, where 1 is closest to `<root-branch>`). If the current branch is `<root-branch>` or not in the stack, note this — the user can still navigate.
 
 ### 2. Parse the argument
 
@@ -27,14 +27,16 @@ The user may pass an argument after `/gs-nav`. Parse it as follows:
 | Argument | Action |
 |---|---|
 | *(none)* | Interactive mode — show the stack and ask the user to pick (see step 3) |
-| `next` or `n` | Move one branch farther from `main` (the child branch) |
-| `prev` or `p` | Move one branch closer to `main` (the parent branch) |
-| `first` or `f` | Jump to the branch closest to `main` (first in the stack) |
-| `last` or `l` | Jump to the branch farthest from `main` (tip of the stack) |
-| `main` | Check out `main` (exit the stack) |
-| A number (e.g. `3`) | Jump to the Nth branch in the stack (1-indexed, 1 = closest to `main`) |
+| `next` or `n` | Move one branch farther from `<root-branch>` (the child branch) |
+| `prev` or `p` | Move one branch closer to `<root-branch>` (the parent branch) |
+| `first` or `f` | Jump to the branch closest to `<root-branch>` (first in the stack) |
+| `last` or `l` | Jump to the branch farthest from `<root-branch>` (tip of the stack) |
+| `root` or `r` | Check out `<root-branch>` (exit the stack) |
+| A number (e.g. `3`) | Jump to the Nth branch in the stack (1-indexed, 1 = closest to `<root-branch>`) |
 
-If the argument doesn't match any of the above, report: "Unknown argument. Use `next`, `prev`, `first`, `last`, `main`, or a branch number."
+If the argument matches the actual root branch name (e.g. `main`, `master`), treat it the same as `root`.
+
+If the argument doesn't match any of the above, report: "Unknown argument. Use `next`, `prev`, `first`, `last`, `root`, or a branch number."
 
 ### 3. Interactive mode (no argument)
 
@@ -42,7 +44,7 @@ Show the stack with numbered branches and the current position:
 
 ```
 Stack:
-  main
+  <root-branch>
     ↓
   [1] feat/auth
     ↓
@@ -50,7 +52,7 @@ Stack:
     ↓
   [3] feat/ui
 
-Jump to: [number] / [n]ext / [p]rev / [f]irst / [l]ast / [main]
+Jump to: [number] / [n]ext / [p]rev / [f]irst / [l]ast / [r]oot
 ```
 
 Wait for the user's response, then parse it using the same rules as step 2.
@@ -59,10 +61,10 @@ Wait for the user's response, then parse it using the same rules as step 2.
 
 Before checking out, validate:
 
-- **`next` from `main`:** Jump to the first stacked branch (closest to `main`). This is not an error — proceed to step 5.
-- **`next` from the tip:** Report "Already at the last branch in the stack (farthest from main). Nowhere to go." and stop.
-- **`prev` from the first branch:** Report "Already the first branch in the stack (closest to main). Use `/gs-nav main` to check out main." and stop.
-- **`prev` from `main`:** Report "Already on main." and stop.
+- **`next` from `<root-branch>`:** Jump to the first stacked branch (closest to `<root-branch>`). This is not an error — proceed to step 5.
+- **`next` from the tip:** Report "Already at the last branch in the stack (farthest from `<root-branch>`). Nowhere to go." and stop.
+- **`prev` from the first branch:** Report "Already the first branch in the stack (closest to `<root-branch>`). Use `/gs-nav root` to check out `<root-branch>`." and stop.
+- **`prev` from `<root-branch>`:** Report "Already on `<root-branch>`." and stop.
 - **Number out of range:** Report "Branch number N is out of range. The stack has N branches." and stop.
 - **Already on the target branch:** Report "Already on [branch name]." and stop.
 
@@ -86,7 +88,7 @@ Position labels:
 - Branch 1: `(1 of N, first in stack)`
 - Branch N (last): `(N of N, last in stack)`
 - Any other: `(M of N)`
-- `main`: `(main, outside stack)`
+- `<root-branch>`: `(<root-branch>, outside stack)`
 
 The skill is done. No further action, no follow-up questions.
 
@@ -96,11 +98,11 @@ The skill is done. No further action, no follow-up questions.
 - Never add a blanket dirty-tree pre-check — let `git checkout` fail naturally if there are conflicts
 - `gh` is not required — this is entirely local
 - In interactive mode, wait for the user to choose before checking out
-- Use "closer to `main`" / "farther from `main`" for direction — never "top" / "bottom"
+- Use "closer to `<root-branch>`" / "farther from `<root-branch>`" for direction — never "top" / "bottom"
 
 ## Edge Cases
 
-- **Current branch is `main`:** The user is outside the stack. `next` jumps to the first stacked branch. `prev` reports "Already on main." Interactive mode still shows the full stack.
+- **Current branch is `<root-branch>`:** The user is outside the stack. `next` jumps to the first stacked branch. `prev` reports "Already on `<root-branch>`." Interactive mode still shows the full stack.
 - **Current branch is not part of the discovered stack:** A stack exists (git config has `git-stack.*` keys) but the current branch isn't in it. Report "Current branch is not part of this stack." and show the stack so the user can pick a branch to navigate to.
 - **Stack has only one branch:** `next` and `prev` both report they're at the edge. `first` and `last` both go to the same branch. Number `1` works.
 - **Checkout fails due to uncommitted changes:** Report the git error and suggest: "Commit or stash your changes first, or use `/gs-create` to start a new branch with your current changes."

--- a/skills/gs-submit/SKILL.md
+++ b/skills/gs-submit/SKILL.md
@@ -21,7 +21,7 @@ Display the full stack before doing anything, so the user knows what will be sub
 
 ```
 Stack to submit:
-  main
+  <root-branch>
   └─ stack/01-feature-a       (no PR yet)
   └─ stack/02-feature-b       (no PR yet)
   └─ stack/03-feature-c       (no PR yet)
@@ -78,7 +78,7 @@ Generate:
 Display the proposed title and description and ask the user to confirm, edit, or skip this branch:
 
 ```
-PR for stack/01-feature-a (base: main)
+PR for stack/01-feature-a (base: <root-branch>)
 Title: feat(auth): add token refresh endpoint
 ---
 Description:
@@ -155,7 +155,7 @@ Possible statuses per branch:
 ## Rules
 
 - Always use `--force-with-lease`, never bare `--force`.
-- PR base is always the branch's `.parent` in the stack metadata, never hardcoded to `main` (unless the parent actually is `main`).
+- PR base is always the branch's `.parent` in the stack metadata — never hardcoded.
 - Idempotent: running twice with no local changes must be a no-op (all branches skipped).
 - Do NOT add `Co-Authored-By` lines anywhere.
 - Do NOT add `🤖 Generated with Claude Code` lines to PR descriptions.
@@ -167,7 +167,7 @@ Possible statuses per branch:
 ## Edge Cases
 
 - **Single-branch stack:** Process that one branch normally.
-- **Bottom branch's parent is main:** Base the PR on `main`. This is correct.
+- **Bottom branch's parent is `<root-branch>`:** Base the PR on `<root-branch>`. This is correct.
 - **Remote branch does not exist yet:** `git push --force-with-lease -u origin <branch>` will create it.
 - **Push rejected (non-fast-forward and lease mismatch):** Report the error, tell the user to run `/gs-sync` to rebase first, and stop processing further branches.
 - **gh pr create fails (e.g. PR already exists but wasn't detected):** Catch the error, report it, and continue with remaining branches.

--- a/skills/gs-sync/SKILL.md
+++ b/skills/gs-sync/SKILL.md
@@ -15,7 +15,7 @@ Display the full stack so the user can see what will be rebased:
 
 ```
 Stack to sync:
-  main
+  <root-branch>
   └─ stack/01-feature-a
   └─ stack/02-feature-b
   └─ stack/03-feature-c
@@ -31,7 +31,7 @@ This ensures the rebase is based on the latest remote state.
 
 ### 3. Rebase the chain
 
-Iterate through the stack from bottom to top (i.e., the branch closest to `main` first, up to the tip).
+Iterate through the stack from bottom to top (i.e., the branch closest to `<root-branch>` first, up to the tip).
 
 For each branch:
 
@@ -42,9 +42,9 @@ For each branch:
 
 2. Determine its parent from `git config git-stack.<branch>.parent`.
 
-3. Rebase onto the parent. For the **bottom branch** (whose parent is `main`), rebase onto `origin/main`:
+3. Rebase onto the parent. For the **bottom branch** (whose parent is `<root-branch>`), rebase onto `origin/<root-branch>`:
    ```
-   git rebase origin/main
+   git rebase origin/<root-branch>
    ```
    For all **subsequent branches**, rebase onto the already-rebased branch below them (the local branch, not its remote):
    ```
@@ -94,7 +94,7 @@ Show a clear summary of what happened:
 
 ```
 Sync complete:
-  stack/01-feature-a   rebased onto origin/main   pushed ✓
+  stack/01-feature-a   rebased onto origin/<root-branch>   pushed ✓
   stack/02-feature-b   rebased onto stack/01       pushed ✓
   stack/03-feature-c   rebased onto stack/02       local only (not pushed)
 ```
@@ -111,14 +111,14 @@ Possible statuses per branch:
 - Always use `--force-with-lease`, never bare `--force`.
 - Never auto-resolve genuine conflicts — always show them to the user and wait.
 - Skip already-merged (squash artifact) commits automatically without asking.
-- Rebase order is always bottom-to-top: the branch closest to `main` is rebased first.
-- The bottom branch always rebases onto `origin/main` (the fetched remote ref), not the local `main`.
+- Rebase order is always bottom-to-top: the branch closest to `<root-branch>` is rebased first.
+- The bottom branch always rebases onto `origin/<root-branch>` (the fetched remote ref), not the local `<root-branch>`.
 - All other branches rebase onto their local parent (which was just rebased in the previous step).
 - Do not modify git-stack metadata during sync — this skill only rebases, it does not restructure the stack.
 
 ## Edge Cases
 
-- **Single-branch stack:** Rebase that one branch onto `origin/main` normally.
+- **Single-branch stack:** Rebase that one branch onto `origin/<root-branch>` normally.
 - **Already up to date:** If a branch is already up to date after rebase, git will report "nothing to do" — note this in the summary as `already up to date`.
 - **Rebase produces empty commit (fully squashed):** This will trigger the already-merged path — use `git rebase --skip`.
 - **User aborts mid-sync:** Run `git rebase --abort` on the current branch, then switch back to the branch the user was on before `/gs-sync` was invoked. Report which branches were successfully rebased and which were not.


### PR DESCRIPTION
## Summary

- Stack discovery now reads `git-stack.root` config to determine the base branch dynamically
- `gs-create` detects the root via `gh repo view` on first stack creation, with fallback chain (`origin/HEAD` → `main` with user confirmation)
- All 9 skills use `<root-branch>` instead of hardcoded `main` in commands and logic
- `gs-nav`: `main` shorthand renamed to `root`/`r`, with backward compat for actual branch names
- CLAUDE.md style guide and README updated to match

## Why

Repos using `master`, `develop`, `trunk`, or other default branches would get incorrect behavior from every skill that hardcoded `main` in git/gh commands.

## How it works

1. `gs-create` detects the root once and writes `git config git-stack.root <branch>`
2. Stack discovery reads this key before building the branch list
3. Legacy stacks (no `git-stack.root` set) fall back to walking parent pointers
4. All skills reference `<root-branch>` from the discovered value

Closes #5